### PR TITLE
Updates to Digitizer and Reformatter

### DIFF
--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -47,11 +47,9 @@ class DataModel : public DAQDataModelBase {
   std::queue<TimeSlice*> pre_sort_queue;
   std::map<trigger_type, std::queue<TimeSlice*> > trigger_queues;
 
-  // True if the corresponding digitizer is active (no communication error
-  // experienced). The stored values are actually booleans, but we cannot use
-  // std::vector<bool> here because we need to be able to take addresses of its
-  // elements.
-  std::vector<uint8_t> active_digitizers;
+  // Describes which digitizers channels are enabled. Set by Digitizer, used by
+  // Reformatter to sync channels data at the beginning of the readout.
+  std::vector<uint16_t> enabled_digitizer_channels;
 
   // Readout of the digitizer data in the CAEN data format
   std::unique_ptr<std::list<std::unique_ptr<std::vector<Hit>>>> raw_readout;

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -40,6 +40,10 @@ class DataModel : public DAQDataModelBase {
   
   DataModel(); ///< Simple constructor 
 
+  bool run_start     = false;
+  bool run_stop      = false;
+  bool change_config = false;
+
   //TTree* GetTTree(std::string name);
   //void AddTTree(std::string name,TTree *tree);
   //void DeleteTTree(std::string name,TTree *tree);

--- a/DataModel/Hit.h
+++ b/DataModel/Hit.h
@@ -3,8 +3,132 @@
 
 #include <cstdint>
 
+// Stores time in 64 bits as a fixed point value with 1/512 ns precision.
+// Bits 10 to 64 store an integer number of ticks, each tick is 2 ns.
+// Bits 0 to 9 store sub-ns fraction.
+// CAEN digitizer time range is 57 bits in this format.
+class Time {
+  public:
+    Time(): time(0) {};
+    Time(const Time& t): time(t.time) {};
+
+    // See Table 2.3 in UM2580_DPSD_UserManual_rev9
+    explicit Time(long double seconds) {
+      seconds /= 2e-9; // Tsampl
+      time = seconds; // Tcoarse
+      seconds *= 1024;
+      time = time << 10 | static_cast<uint64_t>(seconds) & 0x3ff; // Tfine
+    };
+
+    // Construct Time from CAEN digitizer output data.
+    // tag is the trigger time tag, extras provides the most and the least significant bits.
+    // See "Channel aggregate data format" in DPP-PSD documentation.
+    Time(uint32_t tag, uint32_t extras) {
+      time = extras & 0xffff0000; // bits 16 to 31
+      time <<= 31 - 16;
+      time |= tag;
+      time <<= 10;
+      time |= extras & 0x3ff; // bits 0 to 9
+    };
+
+    double seconds() const {
+      return (
+            static_cast<long double>(time >> 10)
+          + static_cast<long double>(time & 0x3ff) / 1024.0L
+      ) * 2e-9L;
+    };
+
+    uint64_t bits() const {
+      return time;
+    };
+
+    Time& operator=(Time t) {
+      time = t.time;
+      return *this;
+    };
+
+    bool operator==(Time t) const {
+      return time == t.time;
+    };
+
+    bool operator!=(Time t) const {
+      return time != t.time;
+    };
+
+    bool operator>(Time t) const {
+      return time > t.time;
+    };
+
+    bool operator>=(Time t) const {
+      return time >= t.time;
+    };
+
+    bool operator<(Time t) const {
+      return time < t.time;
+    };
+
+    bool operator<=(Time t) const {
+      return time <= t.time;
+    };
+
+    Time operator+(Time t) const {
+      return Time(time + t.time);
+    };
+
+    Time& operator+=(Time t) {
+      time += t.time;
+      return *this;
+    };
+
+    Time operator-(Time t) const {
+      return Time(time - t.time);
+    };
+
+    Time& operator-=(Time t) {
+      time -= t.time;
+      return *this;
+    };
+
+    template <typename Number>
+    typename std::enable_if<std::is_arithmetic<Number>::value, Time>::type
+    operator*(Number x) const {
+      return Time(time * x);
+    };
+
+    template <typename Number>
+    typename std::enable_if<std::is_arithmetic<Number>::value, Time&>::type
+    operator*=(Number x) {
+      time *= x;
+      return *this;
+    };
+
+    template <typename Number>
+    typename std::enable_if<std::is_arithmetic<Number>::value, Time>::type
+    operator/(Number x) const {
+      return Time(time / x);
+    };
+
+    template <typename Number>
+    typename std::enable_if<std::is_arithmetic<Number>::value, Time&>::type
+    operator/=(Number x) {
+      time /= x;
+      return *this;
+    };
+
+  private:
+    uint64_t time;
+
+    explicit Time(uint64_t time): time(time) {};
+};
+
+template <typename Number>
+typename std::enable_if<std::is_arithmetic<Number>::value, Time>::type
+operator*(Number x, Time t) {
+  return t * x;
+};
+
 struct Hit {
-  uint64_t time;
+  Time     time;
   uint16_t charge_short;
   uint16_t charge_long;
   uint16_t baseline;

--- a/DataModel/TimeSlice.h
+++ b/DataModel/TimeSlice.h
@@ -13,6 +13,7 @@
 enum class trigger_type {nhits, calib, zero_bais};  
 
 struct TimeSlice {
+  uint64_t time;
   std::vector<Hit> hits;
   std::mutex mutex;
   std::vector<std::pair<trigger_type, unsigned long>> positive_trggers;

--- a/DataModel/TimeSlice.h
+++ b/DataModel/TimeSlice.h
@@ -13,7 +13,7 @@
 enum class trigger_type {nhits, calib, zero_bais};  
 
 struct TimeSlice {
-  uint64_t time;
+  Time time;
   std::vector<Hit> hits;
   std::mutex mutex;
   std::vector<std::pair<trigger_type, unsigned long>> positive_trggers;

--- a/UserTools/Digitizer/Digitizer.cpp
+++ b/UserTools/Digitizer/Digitizer.cpp
@@ -322,18 +322,19 @@ void Digitizer::readout_thread(Thread_args* arg) {
   ReadoutThread* args = static_cast<ReadoutThread*>(arg);
   Digitizer& tool = args->tool;
   DataModel& data = *tool.m_data;
-  try {
-    for (auto digitizer : args->digitizers)
-      if (data.active_digitizers[digitizer->id])
-        try {
-          tool.readout(*digitizer);
-        } catch (caen::Digitizer::Error&) {
-          data.active_digitizers[digitizer->id] = 0;
-          throw;
-        };
-  } catch (std::exception& e) {
-    tool.error() << e.what() << std::endl;
-  };
+  for (auto digitizer : args->digitizers)
+    if (data.active_digitizers[digitizer->id])
+      try {
+        tool.readout(*digitizer);
+      } catch (caen::Digitizer::Error& error) {
+        tool.error()
+          << "digitizer "
+          << static_cast<int>(digitizer->id)
+          << ": "
+          << error.what()
+          << std::endl;
+        data.active_digitizers[digitizer->id] = 0;
+      };
 }
 
 void Digitizer::monitor_thread(Thread_args* arg) {

--- a/UserTools/Digitizer/Digitizer.cpp
+++ b/UserTools/Digitizer/Digitizer.cpp
@@ -291,8 +291,7 @@ void Digitizer::readout(Board& board) {
          event != board.events.end(channel);
          ++event)
     {
-      hit->time         = static_cast<uint64_t>(event->TimeTag) << 32
-                        | event->Extras;
+      hit->time         = Time(event->TimeTag, event->Extras);
       hit->charge_short = event->ChargeShort;
       hit->charge_long  = event->ChargeLong;
 #if 0

--- a/UserTools/Digitizer/Digitizer.cpp
+++ b/UserTools/Digitizer/Digitizer.cpp
@@ -442,7 +442,26 @@ bool Digitizer::Initialise(std::string configfile, DataModel &data) {
 };
 
 bool Digitizer::Execute() {
-  if (!acquiring) start_acquisition();
+  if (digitizers.empty()) return true;
+
+  if (m_data->run_stop && acquiring) stop_acquisition();
+
+  if (m_data->change_config) {
+    bool acq = acquiring;
+    if (acq) stop_acquisition();
+
+    InitialiseConfiguration();
+
+    disconnect();
+
+    connect();
+    configure();
+
+    if (acq) start_acquisition();
+  };
+
+  if (m_data->run_start && !acquiring) start_acquisition();
+
   return true;
 };
 

--- a/UserTools/Digitizer/Digitizer.h
+++ b/UserTools/Digitizer/Digitizer.h
@@ -30,7 +30,9 @@ class Digitizer: public ToolFramework::Tool {
       Digitizer& tool;
       std::vector<Board*> digitizers;
 
-      ReadoutThread(Digitizer& tool): tool(tool) {};
+      ReadoutThread(Digitizer& tool, std::vector<Board*>&& digitizers):
+        tool(tool), digitizers(digitizers)
+      {};
     };
 
     struct MonitorThread : ToolFramework::Thread_args {

--- a/UserTools/Digitizer/Digitizer.h
+++ b/UserTools/Digitizer/Digitizer.h
@@ -20,6 +20,7 @@ class Digitizer: public ToolFramework::Tool {
   private:
     struct Board {
       uint8_t                                                      id;
+      bool                                                         active;
       caen::Digitizer                                              digitizer;
       caen::Digitizer::ReadoutBuffer                               buffer;
       caen::Digitizer::DPPEvents<CAEN_DGTZ_DPP_PSD_Event_t>        events;

--- a/UserTools/Reformatter/Reformatter.cpp
+++ b/UserTools/Reformatter/Reformatter.cpp
@@ -170,10 +170,23 @@ bool Reformatter::Initialise(std::string configfile, DataModel& data) {
 
   long double time = 0.1;
   m_variables.Get("interval", time);
+  if (time <= 0) {
+    *m_data->Log
+      << ML(0) << "Reformatter: invalid time interval: " << time
+      << ", using 0.1 s" << std::endl;
+    time = 0.1;
+  };
   interval = time_from_seconds(time);
 
   dead_time = 10 * interval;
-  if (m_variables.Get("dead_time", time)) dead_time = time_from_seconds(time);
+  if (m_variables.Get("dead_time", time)) {
+    if (time <= 0) {
+      *m_data->Log << ML(0) << "Reformatter: invalid dead time: " << time;
+      time = 10 * time_to_seconds(interval);
+      *m_data->Log << ", using " << time << " s" << std::endl;
+    };
+    dead_time = time_from_seconds(time) + interval;
+  };
 
   if (!current) current.reset(new std::vector<Hit>);
   if (!next) next.reset(new std::vector<Hit>);

--- a/UserTools/Reformatter/Reformatter.cpp
+++ b/UserTools/Reformatter/Reformatter.cpp
@@ -47,10 +47,11 @@ inline static uint16_t decode_baseline(uint16_t baseline) {
 #endif
 }
 
-void Reformatter::send_timeslice(std::vector<Hit>& hits) {
+void Reformatter::send_timeslice(uint64_t time, std::vector<Hit>& hits) {
   if (hits.empty()) return;
 
   std::unique_ptr<TimeSlice> timeslice(new TimeSlice);
+  timeslice->time = time;
   timeslice->hits.insert(
       timeslice->hits.begin(),
       std::make_move_iterator(hits.begin()),
@@ -163,7 +164,7 @@ void Reformatter::reformat() {
           }
       );
 
-      send_timeslice(buffer);
+      send_timeslice(start, buffer);
 
       start = end;
     };

--- a/UserTools/Reformatter/Reformatter.cpp
+++ b/UserTools/Reformatter/Reformatter.cpp
@@ -5,21 +5,6 @@
 
 Reformatter::Reformatter(): Tool() {}
 
-// CAENDigitizer 2.17.3 coupled with DPP-PSD firmware version 136.137 (AMC)
-// 04.25 (ROC) has a bug when the baseline (times 4) is returned as an int16_t
-// rather than uint16_t, with the sign depending on the channel pulse polarity.
-// This function decodes the proper baseline value.
-inline static uint16_t decode_baseline(uint16_t baseline) {
-  // XXX: currently assuming negative pulse polarity
-#if 0
-  // positive pulse polarity
-  return (uint16_t)-baseline / 4;
-#else
-  // negative pulse polarity
-  return baseline / 4;
-#endif
-}
-
 void Reformatter::send_timeslice(Time time, std::vector<Hit>& hits) {
   if (hits.empty()) return;
 
@@ -67,8 +52,6 @@ void Reformatter::reformat() {
 
       for (auto& board : *readouts.back())
         for (auto& hit : *board) {
-          hit.baseline = decode_baseline(hit.baseline);
-
           if (hit.channel >= channels.size()) {
             std::stringstream ss;
             ss << "Unexpected hit channel " << static_cast<int>(hit.channel);

--- a/UserTools/Reformatter/Reformatter.cpp
+++ b/UserTools/Reformatter/Reformatter.cpp
@@ -172,13 +172,27 @@ bool Reformatter::Initialise(std::string configfile, DataModel& data) {
   if (!m_variables.Get("verbose", m_verbose)) m_verbose = 1;
 
   configure();
-  start_reformatting();
 
   ExportConfiguration();
   return true;
 }
 
 bool Reformatter::Execute() {
+  if (m_data->run_stop && reformatting) stop_reformatting();
+
+  if (m_data->change_config) {
+    bool ref = reformatting;
+    if (ref) stop_reformatting();
+
+    InitialiseConfiguration();
+
+    configure();
+
+    if (ref) start_reformatting();
+  };
+
+  if (m_data->run_start && !reformatting) start_reformatting();
+
   return true;
 }
 

--- a/UserTools/Reformatter/Reformatter.cpp
+++ b/UserTools/Reformatter/Reformatter.cpp
@@ -115,7 +115,7 @@ void Reformatter::reformat() {
       if (channel.active && channel.min < start)
         start = channel.min;
 
-    uint64_t end = start + interval;
+    uint64_t end = std::max(start, time) + interval;
 
     // check the time window
     {
@@ -164,6 +164,7 @@ void Reformatter::reformat() {
 
     send_timeslice(*current);
     std::swap(current, next);
+    time = end;
   };
 }
 

--- a/UserTools/Reformatter/Reformatter.cpp
+++ b/UserTools/Reformatter/Reformatter.cpp
@@ -47,17 +47,19 @@ inline static uint16_t decode_baseline(uint16_t baseline) {
 #endif
 }
 
-void Reformatter::ThreadArgs::send(const std::vector<Hit>& hits) {
+void Reformatter::send_timeslice(std::vector<Hit>& hits) {
+  if (hits.empty()) return;
+
   std::unique_ptr<TimeSlice> timeslice(new TimeSlice);
   timeslice->hits.reserve(hits.size());
   for (auto& hit : hits) timeslice->hits.push_back(std::move(hit));
   hits.clear();
 
-  std::lock_guard<std::mutex> lock(tool.m_data->readout_mutex);
-  tool.m_data->readout.push(std::move(timeslice));
+  std::lock_guard<std::mutex> lock(m_data->readout_mutex);
+  m_data->readout.push(std::move(timeslice));
 };
 
-void Reformatter::ThreadArgs::execute() {
+void Reformatter::reformat() {
   /* We wait until the time of the earlist hit available for processing across
    * all channels (`start`) plus the desired timeslice length (`interval`) is
    * less than the time of the latest hit in the channel for all active
@@ -70,102 +72,99 @@ void Reformatter::ThreadArgs::execute() {
    * then sent for processing.
    */
 
-  if (tool.m_data->raw_readout) {
+  while (!stop || !current->empty()) {
+    if (m_data->raw_readout) {
+      {
+        std::lock_guard<std::mutex> lock(m_data->raw_readout_mutex);
+        readouts.push_back(std::move(m_data->raw_readout));
+      };
+
+      for (auto& board : *readouts.back())
+        for (auto& hit : *board) {
+          // Decode CAEN data format
+          hit.time     = decode_time(hit.time);
+          hit.baseline = decode_baseline(hit.baseline);
+
+          if (hit.channel >= channels.size()) {
+            // A new channel is seen. Initialize the `digitizer_active` fields
+            auto i = channels.size();
+            channels.resize(hit.channel + 1);
+            for (; i < channels.size(); ++i)
+              channels[i].digitizer_active
+                = &m_data->active_digitizers[Hit::get_digitizer_id(i)];
+          };
+
+          Channel& channel = channels[hit.channel];
+          if (channel.active) {
+            if (hit.time < channel.min)
+              channel.min = hit.time;
+            else if (hit.time > channel.max)
+              channel.max = hit.time;
+          } else {
+            channel.active = true;
+            channel.min = channel.max = hit.time;
+          };
+        };
+    } else if (current->empty()) {
+      usleep(time_to_seconds(interval) * 0.5e6);
+      continue;
+    };
+
+    auto start = std::numeric_limits<uint64_t>().max();
+    for (auto& channel : channels)
+      if (channel.active && channel.min < start)
+        start = channel.min;
+
+    uint64_t end = start + interval;
+
+    // check the time window
     {
-      std::lock_guard<std::mutex> lock(tool.m_data->raw_readout_mutex);
-      readouts.push_back(std::move(tool.m_data->raw_readout));
-    };
+      bool complete = true;
+      for (auto& channel : channels)
+        if (channel.active && channel.max < end)
+          if (*channel.digitizer_active) {
+            // some channel may yet provide data fitting the current time window
+            complete = false;
+            break;
+          } else
+            // channel's digitizer went inactive
+            channel.active = false;
+      if (!complete && !stop) continue;
+    }
 
-    for (auto& board : *readouts.back())
-      for (auto& hit : *board) {
-        // Decode CAEN data format
-        hit.time     = decode_time(hit.time);
-        hit.baseline = decode_baseline(hit.baseline);
+    // No more hits to expect. Form the timeslice and send it down the toolchain
 
-        if (hit.channel >= channels.size()) {
-          // A new channel is seen. Initialize the `digitizer_active` fields
-          auto i = channels.size();
-          channels.resize(hit.channel + 1);
-          for (; i < channels.size(); ++i)
-            channels[i].digitizer_active
-              = &tool.m_data->active_digitizers[Hit::get_digitizer_id(i)];
-        };
-
-        Channel& channel = channels[hit.channel];
-        if (channel.active) {
-          if (hit.time < channel.min)
-            channel.min = hit.time;
-          else if (hit.time > channel.max)
-            channel.max = hit.time;
-        } else {
-          channel.active = true;
-          channel.min = channel.max = hit.time;
+    // Prepare the timeslice hits. Store events hitting the time window in
+    // current, the rest in next.
+    {
+      size_t i = 0;
+      for (size_t j = 0; j < current->size(); ++j) {
+        auto& hit = (*current)[j];
+        if (hit.time > end)
+          next->push_back(std::move(hit));
+        else {
+          if (i < j) (*current)[i] = std::move(hit);
+          ++i;
         };
       };
-  } else if (current->empty()) {
-    usleep(time_to_seconds(tool.interval) * 0.5e6);
-    return;
-  };
-
-  auto start = std::numeric_limits<uint64_t>().max();
-  for (auto& channel : channels)
-    if (channel.active && channel.min < start)
-      start = channel.min;
-
-  uint64_t end = start + tool.interval;
-
-  // check the time window
-  for (auto& channel : channels)
-    if (channel.active && channel.max < end)
-      if (*channel.digitizer_active)
-        // some channel may yet provide data fitting the current time window
-        return;
-      else
-        // channel's digitizer went inactive
-        channel.active = false;
-
-  // No more hits to expect. Form the timeslice and send it down the toolchain
-
-  // Prepare the timeslice hits. Store events hitting the time window in
-  // current, the rest in next.
-  {
-    size_t i = 0;
-    for (size_t j = 0; j < current->size(); ++j) {
-      auto& hit = (*current)[j];
-      if (hit.time > end)
-        next->push_back(std::move(hit));
-      else {
-        if (i < j) (*current)[i] = std::move(hit);
-        ++i;
-      };
+      current->resize(i);
     };
-    current->resize(i);
+    for (auto& readout : readouts)
+      for (auto& board : *readout)
+        for (auto& hit : *board)
+          (hit.time <= end ? current : next)->push_back(std::move(hit));
+    readouts.clear();
+
+    // Reset the channels min times
+    for (auto& channel : channels) channel.min = channel.max;
+    for (auto& hit : *next) {
+      auto& channel = channels[hit.channel];
+      if (hit.time < channel.min) channel.min = hit.time;
+    };
+
+    send_timeslice(*current);
+    std::swap(current, next);
   };
-  for (auto& readout : readouts)
-    for (auto& board : *readout)
-      for (auto& hit : *board)
-        (hit.time <= end ? current : next)->push_back(std::move(hit));
-  readouts.clear();
-
-  // Copy the hits and send the timeslice
-  send(*current);
-  std::swap(current, next);
-
-  // Reset the channels min times
-  for (auto& channel : channels) channel.min = channel.max;
-  for (auto& hit : *current) {
-    auto& channel = channels[hit.channel];
-    if (hit.time < channel.min) channel.min = hit.time;
-  };
-}
-
-Reformatter::ThreadArgs::~ThreadArgs() {
-  // Send the last hits for processing
-  if (!next->empty()) send(*next);
-}
-
-void Reformatter::Thread(Thread_args* args) {
-  static_cast<ThreadArgs*>(args)->execute();
 }
 
 bool Reformatter::Initialise(std::string configfile, DataModel& data) {
@@ -178,8 +177,11 @@ bool Reformatter::Initialise(std::string configfile, DataModel& data) {
   m_variables.Get("interval", time);
   interval = time_from_seconds(time);
 
-  thread = new ThreadArgs(*this);
-  util.CreateThread("Reformatter", &Thread, thread);
+  if (!current) current.reset(new std::vector<Hit>);
+  if (!next) next.reset(new std::vector<Hit>);
+
+  stop = false;
+  thread = std::thread(&Reformatter::reformat, this);
 
   ExportConfiguration();
   return true;
@@ -190,7 +192,9 @@ bool Reformatter::Execute() {
 }
 
 bool Reformatter::Finalise() {
-  util.KillThread(thread);
-  delete thread;
+  if (!stop) {
+    stop = true;
+    thread.join();
+  };
   return true;
 }

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -47,11 +47,6 @@ class Reformatter: public ToolFramework::Tool {
 
       std::vector<Channel> channels;
 
-      // time of the earliest hit in next or readout (min(channels.min))
-      uint64_t time_min = std::numeric_limits<uint64_t>().max();
-      // time of the latest hit in next or readout (max(channels.max))
-      uint64_t time_max = 0;
-
       ThreadArgs(Reformatter& tool):
         tool(tool),
         current(new std::vector<Hit>()),

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -48,6 +48,9 @@ class Reformatter: public ToolFramework::Tool {
     // target timeslice length
     uint64_t interval;
 
+    // last timeslice target timestamp
+    uint64_t time = 0;
+
     bool stop = true;
     std::thread thread;
 

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -18,11 +18,8 @@ class Reformatter: public ToolFramework::Tool {
   private:
     struct Channel {
       // timespan of hits that haven't been formed into a timeslice yet
-      uint64_t min;
-      uint64_t max;
-
-      // pointer to the digitizer status (see DataModel::active_digitizers)
-      uint8_t* digitizer_active;
+      uint64_t min = 0;
+      uint64_t max = 0;
 
       // we have or expect to have data in this channel
       // (we have seen events coming from this channel and the channel
@@ -47,6 +44,9 @@ class Reformatter: public ToolFramework::Tool {
 
     // target timeslice length
     uint64_t interval;
+
+    // max time to wait for data from a channel
+    uint64_t dead_time;
 
     // last timeslice target timestamp
     uint64_t time = 0;

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -41,8 +41,13 @@ class Reformatter: public ToolFramework::Tool {
     // max time to wait for data from a channel
     Time dead_time;
 
-    bool stop = true;
+    bool reformatting = false;
     std::thread thread;
+
+    void configure();
+
+    void start_reformatting();
+    void stop_reformatting();
 
     void send_timeslice(Time time, std::vector<Hit>& hits);
     void reformat();

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -9,63 +9,50 @@
 class Reformatter: public ToolFramework::Tool {
   public:
     Reformatter();
+    ~Reformatter() { Finalise(); };
 
     bool Initialise(std::string configfile, DataModel& data);
     bool Execute();
     bool Finalise();
 
   private:
-    struct ThreadArgs : Thread_args {
-      struct Channel {
-        // hit times available in next or readout
-        uint64_t min;
-        uint64_t max;
+    struct Channel {
+      // timespan of hits that haven't been formed into a timeslice yet
+      uint64_t min;
+      uint64_t max;
 
-        // pointer to the digitizer status (see DataModel::active_digitizers)
-        uint8_t* digitizer_active;
+      // pointer to the digitizer status (see DataModel::active_digitizers)
+      uint8_t* digitizer_active;
 
-        // we have or expect to have data in this channel
-        // (we have seen events coming from this channel and the channel
-        // digitizer is not marked as inactive)
-        bool active;
-      };
+      // we have or expect to have data in this channel
+      // (we have seen events coming from this channel and the channel
+      // digitizer is not marked as inactive)
+      bool active;
+    };
 
-      Reformatter& tool;
+    std::unique_ptr<std::vector<Hit>> current;
+    std::unique_ptr<std::vector<Hit>> next;
 
-      std::unique_ptr<std::vector<Hit>> current;
-      std::unique_ptr<std::vector<Hit>> next;
-
-      std::vector<
-        std::unique_ptr<
-          std::list<
-            std::unique_ptr<
-              std::vector<Hit>
-            >
+    std::vector<
+      std::unique_ptr<
+        std::list<
+          std::unique_ptr<
+            std::vector<Hit>
           >
         >
-      > readouts;
+      >
+    > readouts;
 
-      std::vector<Channel> channels;
-
-      ThreadArgs(Reformatter& tool):
-        tool(tool),
-        current(new std::vector<Hit>()),
-        next(new std::vector<Hit>())
-      {};
-
-      ~ThreadArgs();
-
-      void send(const std::vector<Hit>& hits);
-      void execute();
-    };
+    std::vector<Channel> channels;
 
     // target timeslice length
     uint64_t interval;
 
-    Utilities util;
-    ThreadArgs* thread;
+    bool stop = true;
+    std::thread thread;
 
-    static void Thread(Thread_args*);
+    void send_timeslice(std::vector<Hit>& hits);
+    void reformat();
 };
 
 #endif

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -17,18 +17,13 @@ class Reformatter: public ToolFramework::Tool {
 
   private:
     struct Channel {
-      // timespan of hits that haven't been formed into a timeslice yet
-      uint64_t min = 0;
-      uint64_t max = 0;
-
-      // we have or expect to have data in this channel
-      // (we have seen events coming from this channel and the channel
-      // digitizer is not marked as inactive)
-      bool active;
+      uint64_t time;  // time of the last hit in the channel
+      bool active; // whether we expect hits in the channel
     };
 
-    std::unique_ptr<std::vector<Hit>> current;
-    std::unique_ptr<std::vector<Hit>> next;
+    std::vector<Channel> channels;
+
+    std::vector<Hit> buffer;
 
     std::vector<
       std::unique_ptr<
@@ -40,16 +35,11 @@ class Reformatter: public ToolFramework::Tool {
       >
     > readouts;
 
-    std::vector<Channel> channels;
-
     // target timeslice length
     uint64_t interval;
 
     // max time to wait for data from a channel
     uint64_t dead_time;
-
-    // last timeslice target timestamp
-    uint64_t time = 0;
 
     bool stop = true;
     std::thread thread;

--- a/UserTools/Reformatter/Reformatter.h
+++ b/UserTools/Reformatter/Reformatter.h
@@ -17,7 +17,7 @@ class Reformatter: public ToolFramework::Tool {
 
   private:
     struct Channel {
-      uint64_t time;  // time of the last hit in the channel
+      Time time; // time of the last hit in the channel
       bool active; // whether we expect hits in the channel
     };
 
@@ -36,15 +36,15 @@ class Reformatter: public ToolFramework::Tool {
     > readouts;
 
     // target timeslice length
-    uint64_t interval;
+    Time interval;
 
     // max time to wait for data from a channel
-    uint64_t dead_time;
+    Time dead_time;
 
     bool stop = true;
     std::thread thread;
 
-    void send_timeslice(std::vector<Hit>& hits);
+    void send_timeslice(Time time, std::vector<Hit>& hits);
     void reformat();
 };
 


### PR DESCRIPTION
Lots of updates fixing various things in Digitizer and Reformatter. Commits where this pull request touches code outside of Digitizer and Reformatter are:

*  cf141733b78b19627bb0e50ed0313590472b63fc implements class `Time` in `DataModel/Hit.h` to store time in a format similar to that read out of the digitizers (same bits, rearranged into a proper order). Note that bits rearranging has moved from reformatter thread to readout thread. Thus `Hit.time` always stores time in the correct format, but the readout thread has a little more work to do. We may discuss alternative approaches if this is not desirable.
* ed5ee13b41ef098996c9afb0cbf8101d84c7deae implements `run_start`, `run_stop`, and  `change_config` variables in `DataModel`. However, no one sets these variables (I have a test tool for this purpose that is not in this branch).

Brief list of other changes:
* If a channel stops supplying data (e.g., a PMT has disconnected), `Reformatter` waits on it for `dead_time` seconds and then continues.
* Time slices are now emitted for each time window beginning from 0. An empty time slice is emitted if no hits occured during its time window. (Previously a time slice began with the first hit that occurs after the previous time slice has ended.) Note however that `Reformatter`'s time is still advanced by hits, so no timeslices are emitted until a hit occurs.
* Baseline is no longer processed in `Reformatter` and provided in the output as read from the digitizer.
* `Reformatter` and `Digitizer` now watch `run_start`, `run_stop`, and `change_config` `DataModel`'s variables in their `Execute`.